### PR TITLE
Add migration and user old schema to delete tokens

### DIFF
--- a/packages/api2/src/database/migrations/30_remove_auth_tokens_from_user.ts
+++ b/packages/api2/src/database/migrations/30_remove_auth_tokens_from_user.ts
@@ -1,0 +1,29 @@
+import { MigrationsContext } from '../interfaces/migration-context.interface';
+import { UserModel } from '../schemas/user/30_user.schema';
+
+const up = async ({ context }: MigrationsContext): Promise<void> => {
+  const users = await UserModel.find({});
+
+  if (users.length === 0) return;
+
+  const updates = await Promise.all(
+    users.map(async (user: any) => {
+      return {
+        updateOne: {
+          filter: { _id: user._id },
+          update: {
+            $unset: {
+              accessToken: 1,
+              refreshToken: 1
+            },
+          },
+          upsert: true,
+        },
+      }
+    }) as any,
+  );
+
+  await UserModel.bulkWrite(updates);
+};
+
+export { up };

--- a/packages/api2/src/database/schemas/user/30_user.schema.ts
+++ b/packages/api2/src/database/schemas/user/30_user.schema.ts
@@ -1,0 +1,48 @@
+import { AuthRole } from '../../../auth/enums/auth-role.enum';
+import mongoose from 'mongoose';
+const { Schema, model } = mongoose;
+const { ObjectId } = Schema.Types;
+
+// Add schema with old attributes to delete them
+export const UserSchema = new Schema({
+  _id: {
+    type: ObjectId,
+    required: true,
+    set: (value: string) => value.toString(),
+  },
+  rewardsEthAddress: {
+    type: String,
+    required: true,
+  },
+  identityEthAddress: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+  },
+  username: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  roles: {
+    type: [
+      {
+        type: String,
+        enum: [AuthRole],
+      },
+    ],
+    default: [AuthRole.USER],
+  },
+  createdAt: {
+    type: Date,
+  },
+  updatedAt: {
+    type: Date,
+  },
+  accessToken: { type: String, select: false },
+  refreshToken: { type: String, select: false },
+});
+
+delete mongoose.models['User'];
+export const UserModel = model('User', UserSchema);

--- a/packages/api2/src/users/schemas/users.schema.ts
+++ b/packages/api2/src/users/schemas/users.schema.ts
@@ -77,14 +77,6 @@ export class User {
   @Prop()
   nonce?: string;
 
-  @Exclude()
-  @Prop()
-  accessToken?: string;
-
-  @Exclude()
-  @Prop()
-  refreshToken?: string;
-
   @ApiResponseProperty()
   @Prop()
   createdAt: Date;


### PR DESCRIPTION
Remove accessToken and RefreshToken from old Api that was saving it in the db, to remove security issues.
We no longer save it in Db only return in headers.