### PR TITLE
fix: resolved the typo in db migration description text

### DIFF
--- a/packages/api/src/database/migrations/01_settings_add_label_description.ts
+++ b/packages/api/src/database/migrations/01_settings_add_label_description.ts
@@ -15,7 +15,7 @@ const settings = [
     key: 'PRAISE_QUANTIFIERS_PER_PRAISE_RECEIVER',
     label: 'Quantifiers Per Praise',
     description:
-      'How many redundant quantifications are assigned to each praise?',
+      'How many quantifiers are assigned to each praise?',
   },
   {
     key: 'PRAISE_PER_QUANTIFIER',

--- a/packages/api2/src/database/migrations/01_settings_add_label_description.ts
+++ b/packages/api2/src/database/migrations/01_settings_add_label_description.ts
@@ -15,7 +15,7 @@ const settings = [
     key: 'PRAISE_QUANTIFIERS_PER_PRAISE_RECEIVER',
     label: 'Quantifiers Per Praise',
     description:
-      'How many redundant quantifications are assigned to each praise?',
+      'How many quantifiers are assigned to each praise?',
   },
   {
     key: 'PRAISE_PER_QUANTIFIER',


### PR DESCRIPTION
Issue [#820](https://github.com/givepraise/praise/issues/820)

Resolved the typo by taking a branch from api2.