### PR TITLE
Kristofer 230306

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -49,6 +49,9 @@ JWT_REFRESH_EXP=25920000
 API_KEYS=
 API_KEY_ROLES=
 
+# The API key salt is used when hashing API keys to store in the database
+API_KEY_SALT=
+
 ###########################################################################
 ## FRONTEND ##
 

--- a/packages/api2/src/api-key/api-key.service.ts
+++ b/packages/api2/src/api-key/api-key.service.ts
@@ -53,8 +53,6 @@ export class ApiKeyService {
       description: `Created API key: ${apiKey.name}`,
     });
 
-    console.log(`Created API key: ${key}`);
-
     return {
       ...apiKey.toObject(),
       key,

--- a/packages/api2/src/auth/strategies/api-key.strategy.ts
+++ b/packages/api2/src/auth/strategies/api-key.strategy.ts
@@ -5,6 +5,7 @@ import { ApiKeyService } from '@/api-key/api-key.service';
 import { AuthContext } from '../auth-context';
 import { ConstantsProvider } from '@/constants/constants.provider';
 import { AuthRole } from '../enums/auth-role.enum';
+import * as bcrypt from 'bcrypt';
 
 @Injectable()
 /**
@@ -32,8 +33,11 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') {
       };
     }
 
+    // Hash the API key as it is stored in the database as a hash.
+    const hash = await bcrypt.hash(apiKey, this.constantsProvider.apiKeySalt);
+
     // Check if the API key has been configured in the database.
-    const key = await this.apiKeyService.findOneByKey(apiKey);
+    const key = await this.apiKeyService.findOneByHash(hash);
     if (key) {
       return {
         roles: [key.role],

--- a/packages/api2/src/constants/constants.provider.ts
+++ b/packages/api2/src/constants/constants.provider.ts
@@ -10,9 +10,12 @@ export const apiKeyRoles = process.env.API_KEY_ROLES
   ? process.env.API_KEY_ROLES.split(',')
   : [];
 
+export const apiKeySalt = process.env.API_KEY_SALT || 'salt';
+
 @Injectable()
 export class ConstantsProvider {
   public uploadDirectory = uploadDirectory;
   public apiKeys = apiKeys;
   public apiKeyRoles = apiKeyRoles;
+  public apiKeySalt = apiKeySalt;
 }

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@types/inquirer": "^8.2.1",
+    "bcrypt": "^5.1.0",
     "dotenv": "^16.0.0",
     "env-cmd": "^10.1.0",
     "inquirer": "^8.2.4"

--- a/packages/setup/src/index.ts
+++ b/packages/setup/src/index.ts
@@ -5,6 +5,7 @@ import { exit } from 'process';
 import os from 'os';
 import { isDocker } from './isDocker';
 import path from 'path';
+import * as bcrypt from 'bcrypt';
 
 interface Answers {
   NODE_ENV: string;
@@ -159,6 +160,7 @@ const run = async (): Promise<void> => {
     API_PORT: process.env.API_PORT,
     API_KEYS: process.env.API_KEYS || apiKeys,
     API_KEY_ROLES: process.env.API_KEY_ROLES || apiKeyRoles,
+    API_KEY_SALT: process.env.API_KEY_SALT || (await bcrypt.genSalt(10)),
     ADMINS: answers.ADMINS,
     JWT_SECRET: process.env.JWT_SECRET || randomString(),
     JWT_ACCESS_EXP: process.env.JWT_ACCESS_EXP,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20114,6 +20114,7 @@ __metadata:
   resolution: "setup@workspace:packages/setup"
   dependencies:
     "@types/inquirer": ^8.2.1
+    bcrypt: ^5.1.0
     dotenv: ^16.0.0
     env-cmd: ^10.1.0
     inquirer: ^8.2.4


### PR DESCRIPTION
We hash api keys when we store them in the db. The salt used to generate these hashes now is generated when you run `yarn setup`. Without a known salt we cannot recreate the hash on incoming requests.