### PR TITLE
Fixed Frontend Caddy Config for logs & upgraded Caddy Image

### DIFF
--- a/packages/frontend/Caddyfile
+++ b/packages/frontend/Caddyfile
@@ -1,10 +1,15 @@
 {$API_URL} {
+  log {
+    output file /var/log/caddy/access.log {
+      format '{remote} - [{when}] "{method} {uri} {proto}" {status} {size}'
+      }
+  }
   handle /api* {
-		reverse_proxy api:{$API_PORT}
-	}
-  handle /uploads* {
-		reverse_proxy api:{$API_PORT}
-	}
+    reverse_proxy api:{$API_PORT}
+  }
+    handle /uploads* {
+    reverse_proxy api:{$API_PORT}
+  }
   handle {
     root * /var/www/praise
     try_files {path} /index.html

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn workspace api build
 RUN yarn workspace frontend build
 
 # note: never use the :latest tag in a production site
-FROM caddy:2.5.2-alpine
+FROM caddy:2.6.4-alpine
 
 COPY ./packages/frontend/Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /usr/src/packages/frontend/build /var/www/praise


### PR DESCRIPTION
In this commit, I fixed the Caddy logging misconfiguration coming from the Caddy file. It prevented the frontend from running.
I have also upgraded the caddy docker image to the latest release 2.6.4-alpine