### PR TITLE
Add/frontend env injection

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -51,6 +51,8 @@ services:
       - caddy_config:/config
     links:
       - api
+    command: >
+      sh -c "cd /var/www/praise && ./init-env.sh && caddy run --config /etc/caddy/Caddyfile"      
 
 volumes:
   mongodb_data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -60,6 +60,8 @@ services:
       - caddy_config:/config
     links:
       - api
+    command: >
+      sh -c "cd /var/www/praise && ./init-env.sh && caddy run --config /etc/caddy/Caddyfile"      
 
 volumes:
   mongodb_data:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -51,6 +51,8 @@ services:
       - caddy_config:/config
     links:
       - api
+    command: >
+      sh -c "cd /var/www/praise && ./init-env.sh && caddy run --config /etc/caddy/Caddyfile"      
 
 volumes:
   mongodb_data:

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -21,8 +21,14 @@ RUN yarn
 # Build the app
 RUN yarn workspace frontend build
 
+# Make sure init-env.sh is executable
+RUN chmod +x ./packages/frontend/build/init-env.sh
+
 # Serve the app with Caddy
 FROM caddy:2.6.4-alpine
+
+# Install envsubst (part of gettext package)
+RUN apk add --no-cache gettext
 
 COPY ./packages/frontend/Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /usr/src/packages/frontend/build /var/www/praise

--- a/packages/frontend/Dockerfile.clean
+++ b/packages/frontend/Dockerfile.clean
@@ -25,3 +25,6 @@ RUN yarn
 
 # Build the app
 RUN yarn workspace frontend build
+
+# Make sure init-env.sh is executable
+RUN chmod +x ./packages/frontend/build/init-env.sh

--- a/packages/frontend/public/env.js
+++ b/packages/frontend/public/env.js
@@ -1,0 +1,7 @@
+// This file is used to inject environment variables into the frontend.
+// Placeholders are replaced by init-env.js during docker compose startup.
+
+window.REACT_APP_ALCHEMY_KEY = '${REACT_APP_ALCHEMY_KEY}';
+
+window.REACT_APP_WALLETCONNECT_PROJECT_ID =
+  '${REACT_APP_WALLETCONNECT_PROJECT_ID}';

--- a/packages/frontend/public/index.html
+++ b/packages/frontend/public/index.html
@@ -1,38 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Acknowledge community contributions, build a culture of giving and gratitude."
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="%PUBLIC_URL%/apple-touch-icon.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="%PUBLIC_URL%/favicon-32x32.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="%PUBLIC_URL%/favicon-16x16.png"
-    />
-    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Acknowledge community contributions, build a culture of giving and gratitude." />
+  <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />
+  <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -41,29 +25,27 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="%PUBLIC_URL%" />
-    <meta property="og:title" content="Praise" />
-    <meta
-      property="og:description"
-      content="Acknowledge community contributions, build a culture of giving and gratitude."
-    />
-    <meta property="og:image" content="%PUBLIC_URL%/Share.png" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="%PUBLIC_URL%" />
+  <meta property="og:title" content="Praise" />
+  <meta property="og:description"
+    content="Acknowledge community contributions, build a culture of giving and gratitude." />
+  <meta property="og:image" content="%PUBLIC_URL%/Share.png" />
 
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="%PUBLIC_URL%" />
-    <meta property="twitter:title" content="Praise" />
-    <meta
-      property="twitter:description"
-      content="Acknowledge community contributions, build a culture of giving and gratitude."
-    />
-    <meta property="twitter:image" content="%PUBLIC_URL%/Share.png" />
-    <title>Praise</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <meta property="twitter:card" content="summary_large_image" />
+  <meta property="twitter:url" content="%PUBLIC_URL%" />
+  <meta property="twitter:title" content="Praise" />
+  <meta property="twitter:description"
+    content="Acknowledge community contributions, build a culture of giving and gratitude." />
+  <meta property="twitter:image" content="%PUBLIC_URL%/Share.png" />
+  <title>Praise</title>
+  <script src="/env.js" defer></script>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -73,5 +55,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/packages/frontend/public/init-env.sh
+++ b/packages/frontend/public/init-env.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eu
+
+# Initialize env.js, replace placeholders with environment variables
+envsubst < "env.js" > "env.js.tmp" && mv "env.js.tmp" "env.js"

--- a/packages/frontend/src/providers/Web3Provider.tsx
+++ b/packages/frontend/src/providers/Web3Provider.tsx
@@ -12,17 +12,33 @@ import { publicProvider } from 'wagmi/providers/public';
 import { mainnet } from 'wagmi/chains';
 import { alchemyProvider } from 'wagmi/providers/alchemy';
 
+interface WindowWithEnv extends Window {
+  REACT_APP_ALCHEMY_KEY?: string;
+  REACT_APP_WALLETCONNECT_PROJECT_ID?: string;
+}
+
+const win = window as WindowWithEnv;
+
+const REACT_APP_ALCHEMY_KEY =
+  process.env.REACT_APP_ALCHEMY_KEY || win.REACT_APP_ALCHEMY_KEY;
+
+const REACT_APP_WALLETCONNECT_PROJECT_ID =
+  process.env.REACT_APP_WALLETCONNECT_PROJECT_ID ||
+  win.REACT_APP_WALLETCONNECT_PROJECT_ID;
+
 const { chains, provider } = configureChains(
   [mainnet],
   [
-    alchemyProvider({ apiKey: process.env.REACT_APP_ALCHEMY_KEY as string }),
+    alchemyProvider({
+      apiKey: REACT_APP_ALCHEMY_KEY || '',
+    }),
     publicProvider(),
   ]
 );
 
 const { connectors } = getDefaultWallets({
   appName: 'Praise',
-  projectId: process.env.REACT_APP_WALLETCONNECT_PROJECT_ID as string,
+  projectId: REACT_APP_WALLETCONNECT_PROJECT_ID,
   chains,
 });
 
@@ -47,10 +63,10 @@ interface Web3ProviderProps {
 }
 
 export function Web3Provider({ children }: Web3ProviderProps): JSX.Element {
-  if (!process.env.REACT_APP_ALCHEMY_KEY) {
+  if (!REACT_APP_ALCHEMY_KEY) {
     throw new Error('REACT_APP_ALCHEMY_KEY is not set');
   }
-  if (!process.env.REACT_APP_WALLETCONNECT_PROJECT_ID) {
+  if (!REACT_APP_WALLETCONNECT_PROJECT_ID) {
     throw new Error('REACT_APP_WALLETCONNECT_PROJECT_ID is not set');
   }
   return (

--- a/packages/setup/src/index.ts
+++ b/packages/setup/src/index.ts
@@ -176,6 +176,9 @@ const run = async (): Promise<void> => {
     JWT_REFRESH_EXP: process.env.JWT_REFRESH_EXP,
     FRONTEND_URL: frontendUrl(answers),
     REACT_APP_SERVER_URL: serverUrl(answers),
+    REACT_APP_ALCHEMY_KEY: process.env.REACT_APP_ALCHEMY_KEY,
+    REACT_APP_WALLETCONNECT_PROJECT_ID:
+      process.env.REACT_APP_WALLETCONNECT_PROJECT_ID,
     FRONTEND_PORT: process.env.FRONTEND_PORT,
     LOGGER_LEVEL: process.env.LOGGER_LEVEL,
     DISCORD_TOKEN: answers.DISCORD_TOKEN,


### PR DESCRIPTION
This PR add support for injecting env variables in the prebuilt frontend docker image. We need to be able to change alchemy key and wallet connect project id without having to rebuild frontend image. 

## env.js

Env template file with placeholders that get replaced on docker compose startup.

## init-env.sh

The env replacement script that is run after frontend image is built.