### PR TITLE
[WIP]: PRAISE_GIVER_ROLE_ID default null and bot settings migration

### DIFF
--- a/packages/api-types/out/schema.ts
+++ b/packages/api-types/out/schema.ts
@@ -3,241 +3,242 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-  '/api/activate': {
+  "/api/activate": {
     /** Activate a user account in order to be able to give praise and receive rewards. Activation a user account creates a new User object or adds user account to User if it already exists. */
-    post: operations['ActivateController_activate'];
+    post: operations["ActivateController_activate"];
   };
-  '/api/users/export/json': {
+  "/api/users/export/json": {
     /** Export users document to json */
-    get: operations['UsersController_exportJson'];
+    get: operations["UsersController_exportJson"];
   };
-  '/api/users/export/csv': {
+  "/api/users/export/csv": {
     /** Export users document to csv */
-    get: operations['UsersController_exportCsv'];
+    get: operations["UsersController_exportCsv"];
   };
-  '/api/users/export/parquet': {
+  "/api/users/export/parquet": {
     /** Export users document to parquet */
-    get: operations['UsersController_exportParquet'];
+    get: operations["UsersController_exportParquet"];
   };
-  '/api/users': {
-    get: operations['UsersController_findAll'];
+  "/api/users": {
+    get: operations["UsersController_findAll"];
   };
-  '/api/users/{id}': {
-    get: operations['UsersController_findOne'];
+  "/api/users/{id}": {
+    get: operations["UsersController_findOne"];
     /** Updates a user */
-    patch: operations['UsersController_update'];
+    patch: operations["UsersController_update"];
   };
-  '/api/users/{id}/addRole': {
-    patch: operations['UsersController_addRole'];
+  "/api/users/{id}/addRole": {
+    patch: operations["UsersController_addRole"];
   };
-  '/api/users/{id}/removeRole': {
-    patch: operations['UsersController_removeRole'];
+  "/api/users/{id}/removeRole": {
+    patch: operations["UsersController_removeRole"];
   };
-  '/api/periods/export/json': {
+  "/api/periods/export/json": {
     /** Export periods document to json */
-    get: operations['PeriodsController_exportJson'];
+    get: operations["PeriodsController_exportJson"];
   };
-  '/api/periods/export/csv': {
+  "/api/periods/export/csv": {
     /** Export periods document to csv */
-    get: operations['PeriodsController_exportCsv'];
+    get: operations["PeriodsController_exportCsv"];
   };
-  '/api/periods/export/parquet': {
+  "/api/periods/export/parquet": {
     /** Export periods document to parquet */
-    get: operations['PeriodsController_exportParquet'];
+    get: operations["PeriodsController_exportParquet"];
   };
-  '/api/periods': {
+  "/api/periods": {
     /** List all periods */
-    get: operations['PeriodsController_findAllPaginated'];
+    get: operations["PeriodsController_findAllPaginated"];
     /** Create a new period */
-    post: operations['PeriodsController_create'];
+    post: operations["PeriodsController_create"];
   };
-  '/api/periods/{id}': {
+  "/api/periods/{id}": {
     /** Find period by id */
-    get: operations['PeriodsController_findOne'];
+    get: operations["PeriodsController_findOne"];
     /** Update a period */
-    patch: operations['PeriodsController_update'];
+    patch: operations["PeriodsController_update"];
   };
-  '/api/periods/{id}/close': {
+  "/api/periods/{id}/close": {
     /** Close a period */
-    patch: operations['PeriodsController_close'];
+    patch: operations["PeriodsController_close"];
   };
-  '/api/periods/{id}/praise': {
+  "/api/periods/{id}/praise": {
     /** Fetch all Praise in a period */
-    get: operations['PeriodsController_praise'];
+    get: operations["PeriodsController_praise"];
   };
-  '/api/periods/{periodId}/praise/receiver/{receiverId}': {
+  "/api/periods/{periodId}/praise/receiver/{receiverId}": {
     /** Fetch all Praise in a period for a given receiver */
-    get: operations['PeriodsController_praiseByReceiver'];
+    get: operations["PeriodsController_praiseByReceiver"];
   };
-  '/api/periods/{periodId}/praise/giver/{giverId}': {
+  "/api/periods/{periodId}/praise/giver/{giverId}": {
     /** Fetch all Praise in a period for a given giver */
-    get: operations['PeriodsController_praiseByGiver'];
+    get: operations["PeriodsController_praiseByGiver"];
   };
-  '/api/periods/{periodId}/praise/quantifier/{quantifierId}': {
+  "/api/periods/{periodId}/praise/quantifier/{quantifierId}": {
     /** Fetch all Praise in a period for a given quantifier */
-    get: operations['PeriodsController_praiseByQuantifier'];
+    get: operations["PeriodsController_praiseByQuantifier"];
   };
-  '/api/periods/{id}/verifyQuantifierPoolSize': {
+  "/api/periods/{id}/verifyQuantifierPoolSize": {
     /** Verify quantifier pool size */
-    get: operations['PeriodsController_verifyQuantifierPoolSize'];
+    get: operations["PeriodsController_verifyQuantifierPoolSize"];
   };
-  '/api/periods/{id}/assignQuantifiers': {
+  "/api/periods/{id}/assignQuantifiers": {
     /** Assign quantifiers to period */
-    patch: operations['PeriodsController_assignQuantifiers'];
+    patch: operations["PeriodsController_assignQuantifiers"];
   };
-  '/api/periods/{id}/replaceQuantifier': {
+  "/api/periods/{id}/replaceQuantifier": {
     /** Replace quantifier in period */
-    patch: operations['PeriodsController_replaceQuantifier'];
+    patch: operations["PeriodsController_replaceQuantifier"];
   };
-  '/api/event-log': {
+  "/api/event-log": {
     /** List event logs, paginated results */
-    get: operations['EventLogController_findAllPaginated'];
+    get: operations["EventLogController_findAllPaginated"];
   };
-  '/api/event-log/types': {
+  "/api/event-log/types": {
     /** List event log types */
-    get: operations['EventLogController_types'];
+    get: operations["EventLogController_types"];
   };
-  '/api/settings': {
+  "/api/settings": {
     /** List all settings. */
-    get: operations['SettingsController_findAll'];
+    get: operations["SettingsController_findAll"];
   };
-  '/api/settings/{id}': {
+  "/api/settings/{id}": {
     /** Get a setting. */
-    get: operations['SettingsController_findOne'];
+    get: operations["SettingsController_findOne"];
     /** Set a value for a setting. */
-    patch: operations['SettingsController_set'];
+    patch: operations["SettingsController_set"];
   };
-  '/api/settings/{id}/upload': {
+  "/api/settings/{id}/upload": {
     /** Upload a file for a setting */
-    patch: operations['SettingsController_setWithUpload'];
+    patch: operations["SettingsController_setWithUpload"];
   };
-  '/api/settings/uploads/{file}': {
+  "/api/settings/uploads/{file}": {
     /** Serve an uploaded settings file. */
-    get: operations['SettingsController_serveUpload'];
+    get: operations["SettingsController_serveUpload"];
   };
-  '/api/periods/{periodId}/settings': {
+  "/api/periods/{periodId}/settings": {
     /** List all period settings. */
-    get: operations['PeriodSettingsController_findAll'];
+    get: operations["PeriodSettingsController_findAll"];
   };
-  '/api/periods/{periodId}/settings/{settingId}': {
+  "/api/periods/{periodId}/settings/{settingId}": {
     /** Get a period setting. */
-    get: operations['PeriodSettingsController_findOne'];
+    get: operations["PeriodSettingsController_findOne"];
     /** Set value for a period setting. */
-    patch: operations['PeriodSettingsController_set'];
+    patch: operations["PeriodSettingsController_set"];
   };
-  '/api/praise': {
+  "/api/praise": {
     /** List praise items, paginated results */
-    get: operations['PraiseController_findAllPaginated'];
+    get: operations["PraiseController_findAllPaginated"];
     /** Create praise item */
-    post: operations['PraiseController_praise'];
+    post: operations["PraiseController_praise"];
   };
-  '/api/praise/export/json': {
+  "/api/praise/export/json": {
     /** Export praise document to json */
-    get: operations['PraiseController_exportJson'];
+    get: operations["PraiseController_exportJson"];
   };
-  '/api/praise/export/csv': {
+  "/api/praise/export/csv": {
     /** Export praise document to csv */
-    get: operations['PraiseController_exportCsv'];
+    get: operations["PraiseController_exportCsv"];
   };
-  '/api/praise/export/parquet': {
+  "/api/praise/export/parquet": {
     /** Export praise document to parquet */
-    get: operations['PraiseController_exportParquet'];
+    get: operations["PraiseController_exportParquet"];
   };
-  '/api/praise/{id}': {
+  "/api/praise/{id}": {
     /** Find praise item by id */
-    get: operations['PraiseController_findOne'];
+    get: operations["PraiseController_findOne"];
   };
-  '/api/praise/forward': {
+  "/api/praise/forward": {
     /** Forward praise item */
-    post: operations['PraiseController_forward'];
+    post: operations["PraiseController_forward"];
   };
-  '/api/useraccounts': {
+  "/api/useraccounts": {
     /** UserAccount list */
-    get: operations['UserAccountsController_findAll'];
+    get: operations["UserAccountsController_findAll"];
     /** Create a UserAccount */
-    post: operations['UserAccountsController_create'];
+    post: operations["UserAccountsController_create"];
   };
-  '/api/useraccounts/export/json': {
+  "/api/useraccounts/export/json": {
     /** Export userAccounts document to json */
-    get: operations['UserAccountsController_exportJson'];
+    get: operations["UserAccountsController_exportJson"];
   };
-  '/api/useraccounts/export/csv': {
+  "/api/useraccounts/export/csv": {
     /** Export userAccounts document to csv */
-    get: operations['UserAccountsController_exportCsv'];
+    get: operations["UserAccountsController_exportCsv"];
   };
-  '/api/useraccounts/export/parquet': {
+  "/api/useraccounts/export/parquet": {
     /** Export userAccounts document to parquet */
-    get: operations['UserAccountsController_exportParquet'];
+    get: operations["UserAccountsController_exportParquet"];
   };
-  '/api/useraccounts/{id}': {
+  "/api/useraccounts/{id}": {
     /** Get a UserAccount. */
-    get: operations['UserAccountsController_findOne'];
+    get: operations["UserAccountsController_findOne"];
     /** Update UserAccount */
-    patch: operations['UserAccountsController_update'];
+    patch: operations["UserAccountsController_update"];
   };
-  '/api/api-key': {
+  "/api/api-key": {
     /** List all API keys */
-    get: operations['ApiKeyController_findAll'];
+    get: operations["ApiKeyController_findAll"];
     /** Create API key */
-    post: operations['ApiKeyController_createApiKey'];
+    post: operations["ApiKeyController_createApiKey"];
   };
-  '/api/api-key/{id}': {
+  "/api/api-key/{id}": {
     /** Get API key by ID */
-    get: operations['ApiKeyController_findOne'];
+    get: operations["ApiKeyController_findOne"];
     /** Update API key description */
-    put: operations['ApiKeyController_updateApiKeyDescription'];
+    put: operations["ApiKeyController_updateApiKeyDescription"];
     /** Revoke API key */
-    delete: operations['ApiKeyController_revokeApiKey'];
+    delete: operations["ApiKeyController_revokeApiKey"];
   };
-  '/api/auth/eth-signature/nonce': {
+  "/api/auth/eth-signature/nonce": {
     /** Generates a nonce for the user and returns it */
-    post: operations['EthSignatureController_nonce'];
+    post: operations["EthSignatureController_nonce"];
   };
-  '/api/auth/eth-signature/login': {
+  "/api/auth/eth-signature/login": {
     /** Verifies a user's signature and returns a JWT token */
-    post: operations['EthSignatureController_login'];
+    post: operations["EthSignatureController_login"];
   };
-  '/api/communities': {
-    get: operations['CommunityController_findAll'];
+  "/api/communities": {
+    get: operations["CommunityController_findAll"];
     /** Create a new community */
-    post: operations['CommunityController_create'];
+    post: operations["CommunityController_create"];
   };
-  '/api/communities/{id}': {
-    get: operations['CommunityController_findOne'];
+  "/api/communities/{id}": {
+    get: operations["CommunityController_findOne"];
     /** Update community */
-    patch: operations['CommunityController_update'];
+    patch: operations["CommunityController_update"];
   };
-  '/api/communities/isNameAvailable': {
-    get: operations['CommunityController_isNameAvailable'];
+  "/api/communities/isNameAvailable": {
+    get: operations["CommunityController_isNameAvailable"];
   };
-  '/api/communities/{id}/discord/link': {
+  "/api/communities/{id}/discord/link": {
     /** Link discord to community */
-    patch: operations['CommunityController_linkDiscord'];
+    patch: operations["CommunityController_linkDiscord"];
   };
-  '/api/quantifications/export/json': {
+  "/api/quantifications/export/json": {
     /** Export quantifications document to json */
-    get: operations['QuantificationsController_exportJson'];
+    get: operations["QuantificationsController_exportJson"];
   };
-  '/api/quantifications/export/csv': {
+  "/api/quantifications/export/csv": {
     /** Export quantifications document to csv */
-    get: operations['QuantificationsController_exportCsv'];
+    get: operations["QuantificationsController_exportCsv"];
   };
-  '/api/quantifications/export/parquet': {
+  "/api/quantifications/export/parquet": {
     /** Export quantifications document to parquet */
-    get: operations['QuantificationsController_exportParquet'];
+    get: operations["QuantificationsController_exportParquet"];
   };
-  '/api/quantifications/multiple': {
+  "/api/quantifications/multiple": {
     /** Quantify multiple praise items */
-    patch: operations['QuantificationsController_quantifyMultiple'];
+    patch: operations["QuantificationsController_quantifyMultiple"];
   };
-  '/api/quantifications/{id}': {
+  "/api/quantifications/{id}": {
     /** Quantify praise item by id */
-    patch: operations['QuantificationsController_quantify'];
+    patch: operations["QuantificationsController_quantify"];
   };
-  '/api/reports': {
+  "/api/reports": {
     /** List all report manifests */
-    get: operations['ReportsController_listAllReports'];
+    get: operations["ReportsController_listAllReports"];
   };
 }
 
@@ -262,17 +263,7 @@ export interface components {
       rewardsEthAddress: string;
       /** @example darth */
       username: string;
-      roles: readonly (
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB'
-      )[];
+      roles: readonly ("USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB")[];
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -281,7 +272,7 @@ export interface components {
     UserAccount: {
       /** @example 63b428f7d9ca4f6ff5370d05 */
       _id: string;
-      user?: components['schemas']['UserNoUserAccountsDto'];
+      user?: components["schemas"]["UserNoUserAccountsDto"];
       /** @example 098098098098098 */
       accountId: string;
       /** @example darth#6755 */
@@ -304,18 +295,8 @@ export interface components {
       rewardsEthAddress: string;
       /** @example darth */
       username: string;
-      roles: readonly (
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB'
-      )[];
-      accounts: readonly components['schemas']['UserAccount'][];
+      roles: readonly ("USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB")[];
+      accounts: readonly (components["schemas"]["UserAccount"])[];
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -330,18 +311,8 @@ export interface components {
       rewardsEthAddress: string;
       /** @example darth */
       username: string;
-      roles: readonly (
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB'
-      )[];
-      accounts: readonly components['schemas']['UserAccount'][];
+      roles: readonly ("USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB")[];
+      accounts: readonly (components["schemas"]["UserAccount"])[];
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -359,16 +330,7 @@ export interface components {
     };
     UpdateUserRoleInputDto: {
       /** @enum {string} */
-      role:
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB';
+      role: "USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB";
     };
     Period: {
       /** @example 621f802b813dbdba9eeaf7d7 */
@@ -376,7 +338,7 @@ export interface components {
       /** @example June 2021 */
       name: string;
       /** @enum {string} */
-      status: 'OPEN' | 'QUANTIFY' | 'CLOSED';
+      status: "OPEN" | "QUANTIFY" | "CLOSED";
       /** Format: date-time */
       endDate: string;
       /** Format: date-time */
@@ -403,7 +365,7 @@ export interface components {
       prevPage?: Record<string, never>;
       /** @example 3 */
       nextPage?: Record<string, never>;
-      docs: readonly components['schemas']['Period'][];
+      docs: readonly (components["schemas"]["Period"])[];
       meta?: Record<string, never>;
     };
     Quantification: {
@@ -422,12 +384,12 @@ export interface components {
       /** @example 639b178f19296ee0f2d0585d */
       praise: string;
       /**
-       * Format: date-time
+       * Format: date-time 
        * @example 2021-06-01T00:00:00.000Z
        */
       createdAt: string;
       /**
-       * Format: date-time
+       * Format: date-time 
        * @example 2021-06-01T00:00:00.000Z
        */
       updatedAt: string;
@@ -447,7 +409,7 @@ export interface components {
       finishedCount: number;
       /** @example 1 */
       praiseCount: number;
-      quantifications: components['schemas']['Quantification'][];
+      quantifications: (components["schemas"]["Quantification"])[];
     };
     PeriodDetailsGiverReceiverDto: {
       /** @example 63b428f7d9ca4f6ff5370d05 */
@@ -477,16 +439,16 @@ export interface components {
       /** @example June 2021 */
       name: string;
       /** @enum {string} */
-      status: 'OPEN' | 'QUANTIFY' | 'CLOSED';
+      status: "OPEN" | "QUANTIFY" | "CLOSED";
       /** Format: date-time */
       endDate: string;
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
       updatedAt: string;
-      quantifiers?: readonly components['schemas']['PeriodDetailsQuantifierDto'][];
-      givers?: readonly components['schemas']['PeriodDetailsGiverReceiverDto'][];
-      receivers?: readonly components['schemas']['PeriodDetailsGiverReceiverDto'][];
+      quantifiers?: readonly (components["schemas"]["PeriodDetailsQuantifierDto"])[];
+      givers?: readonly (components["schemas"]["PeriodDetailsGiverReceiverDto"])[];
+      receivers?: readonly (components["schemas"]["PeriodDetailsGiverReceiverDto"])[];
       /** @example 543 */
       numberOfPraise: number;
     };
@@ -531,10 +493,10 @@ export interface components {
       sourceName: string;
       /** @example 144 */
       score: number;
-      receiver: components['schemas']['UserAccountWithUserRefDto'];
-      giver: components['schemas']['UserAccountWithUserRefDto'];
-      forwarder?: components['schemas']['UserAccountWithUserRefDto'];
-      quantifications: readonly components['schemas']['Quantification'][];
+      receiver: components["schemas"]["UserAccountWithUserRefDto"];
+      giver: components["schemas"]["UserAccountWithUserRefDto"];
+      forwarder?: components["schemas"]["UserAccountWithUserRefDto"];
+      quantifications: readonly (components["schemas"]["Quantification"])[];
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -542,12 +504,12 @@ export interface components {
     };
     VerifyQuantifierPoolSizeDto: {
       /**
-       * @description The number of quantifiers in the pool
+       * @description The number of quantifiers in the pool 
        * @example 10
        */
       quantifierPoolSize: number;
       /**
-       * @description The number of quantifiers needed in the pool
+       * @description The number of quantifiers needed in the pool 
        * @example 10
        */
       quantifierPoolSizeNeeded: number;
@@ -573,18 +535,18 @@ export interface components {
       sourceName: string;
       /** @example 144 */
       score: number;
-      receiver: components['schemas']['UserAccount'];
-      giver: components['schemas']['UserAccount'];
-      forwarder?: components['schemas']['UserAccount'];
-      quantifications: readonly components['schemas']['Quantification'][];
+      receiver: components["schemas"]["UserAccount"];
+      giver: components["schemas"]["UserAccount"];
+      forwarder?: components["schemas"]["UserAccount"];
+      quantifications: readonly (components["schemas"]["Quantification"])[];
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
       updatedAt: string;
     };
     ReplaceQuantifierResponseDto: {
-      praises: readonly components['schemas']['Praise'][];
-      period: components['schemas']['PeriodDetailsDto'];
+      praises: readonly (components["schemas"]["Praise"])[];
+      period: components["schemas"]["PeriodDetailsDto"];
     };
     UserAccountNoUserId: {
       /** @example 63b428f7d9ca4f6ff5370d05 */
@@ -604,14 +566,7 @@ export interface components {
     };
     EventLogType: {
       /** @enum {string} */
-      key:
-        | 'PERMISSION'
-        | 'AUTHENTICATION'
-        | 'PERIOD'
-        | 'PRAISE'
-        | 'QUANTIFICATION'
-        | 'SETTING'
-        | 'USER_ACCOUNT';
+      key: "PERMISSION" | "AUTHENTICATION" | "PERIOD" | "PRAISE" | "QUANTIFICATION" | "SETTING" | "USER_ACCOUNT";
       /** @example An action that changes user permissions */
       label: string;
       /** @example A user's permissions were changed */
@@ -620,22 +575,22 @@ export interface components {
     EventLog: {
       /** @example 621f802b813dbdba9eeaf7d7 */
       _id: string;
-      user?: components['schemas']['User'];
-      useraccount?: components['schemas']['UserAccountNoUserId'];
+      user?: components["schemas"]["User"];
+      useraccount?: components["schemas"]["UserAccountNoUserId"];
       /** @example 621f802b813dbdba9eeaf7d7 */
       apiKey?: string;
       /** @example 621f802b813dbdba9eeaf7d7 */
       period?: string;
-      type: components['schemas']['EventLogType'];
+      type: components["schemas"]["EventLogType"];
       /** @example A description of the event */
       description: string;
       /**
-       * Format: date-time
+       * Format: date-time 
        * @example 2023-03-01T22:51:20.012Z
        */
       createdAt: string;
       /**
-       * Format: date-time
+       * Format: date-time 
        * @example 2023-03-01T22:51:20.012Z
        */
       updatedAt: string;
@@ -659,7 +614,7 @@ export interface components {
       prevPage?: Record<string, never>;
       /** @example 3 */
       nextPage?: Record<string, never>;
-      docs: readonly components['schemas']['EventLog'][];
+      docs: readonly (components["schemas"]["EventLog"])[];
       meta?: Record<string, never>;
     };
     Setting: {
@@ -670,21 +625,11 @@ export interface components {
       /** @example 666 */
       value: string;
       /** @example 666 */
-      valueRealized: string | string[] | boolean | number | number[];
+      valueRealized: string | (string)[] | boolean | number | (number)[];
       /** @example 555 */
       defaultValue: string;
       /** @enum {string} */
-      type:
-        | 'Integer'
-        | 'Float'
-        | 'String'
-        | 'Textarea'
-        | 'Boolean'
-        | 'IntegerList'
-        | 'StringList'
-        | 'Image'
-        | 'Radio'
-        | 'JSON';
+      type: "Integer" | "Float" | "String" | "Textarea" | "Boolean" | "IntegerList" | "StringList" | "Image" | "Radio" | "JSON";
       /** @example Quantifiers Per Praise */
       label: string;
       /** @example How many redundant quantifications are assigned to each praise? */
@@ -704,11 +649,11 @@ export interface components {
     PeriodSetting: {
       /** @example 62291b7ea8b1619f78818524 */
       _id: string;
-      period: components['schemas']['Period'];
-      setting: components['schemas']['Setting'];
+      period: components["schemas"]["Period"];
+      setting: components["schemas"]["Setting"];
       value: string;
       /** @example 666 */
-      valueRealized: string | string[] | boolean | number | number[];
+      valueRealized: string | (string)[] | boolean | number | (number)[];
     };
     SetPeriodSettingDto: {
       value: string;
@@ -732,7 +677,7 @@ export interface components {
       prevPage?: Record<string, never>;
       /** @example 3 */
       nextPage?: Record<string, never>;
-      docs: readonly components['schemas']['Praise'][];
+      docs: readonly (components["schemas"]["Praise"])[];
       meta?: Record<string, never>;
     };
     PraiseCreateInputDto: {
@@ -744,8 +689,8 @@ export interface components {
       sourceId: string;
       /** @example DISCORD:Token%20Engineering%20Commons:%F0%9F%99%8F%EF%BD%9Cpraise */
       sourceName: string;
-      receiverIds: string[];
-      giver: components['schemas']['UserAccount'];
+      receiverIds: (string)[];
+      giver: components["schemas"]["UserAccount"];
     };
     PraiseForwardInputDto: {
       /** @example for making edits in the welcome text */
@@ -756,9 +701,9 @@ export interface components {
       sourceId: string;
       /** @example DISCORD:Token%20Engineering%20Commons:%F0%9F%99%8F%EF%BD%9Cpraise */
       sourceName: string;
-      receiverIds: string[];
-      giver: components['schemas']['UserAccount'];
-      forwarder: components['schemas']['UserAccount'];
+      receiverIds: (string)[];
+      giver: components["schemas"]["UserAccount"];
+      forwarder: components["schemas"]["UserAccount"];
     };
     CreateUserAccountInputDto: {
       /** @example 098098098098098 */
@@ -777,7 +722,7 @@ export interface components {
     CreateUserAccountResponseDto: {
       /** @example 63b428f7d9ca4f6ff5370d05 */
       _id: string;
-      user?: components['schemas']['UserNoUserAccountsDto'];
+      user?: components["schemas"]["UserNoUserAccountsDto"];
       /** @example 098098098098098 */
       accountId: string;
       /** @example darth#6755 */
@@ -810,7 +755,7 @@ export interface components {
     UpdateUserAccountResponseDto: {
       /** @example 63b428f7d9ca4f6ff5370d05 */
       _id: string;
-      user?: components['schemas']['UserNoUserAccountsDto'];
+      user?: components["schemas"]["UserNoUserAccountsDto"];
       /** @example 098098098098098 */
       accountId: string;
       /** @example darth#6755 */
@@ -830,16 +775,7 @@ export interface components {
       /** @example My API Key */
       description: string;
       /** @enum {string} */
-      role:
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB';
+      role: "USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB";
     };
     CreateApiKeyResponseDto: {
       /** @example 639b178f19296ee0f2d0585d */
@@ -851,16 +787,7 @@ export interface components {
       /** @example $2b$10$hfRNI.V7ewuN/K.5eSt6oelaQ.FDj6irfUNR9wkKnL/qsNT23aE4i */
       hash: string;
       /** @enum {string} */
-      role:
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB';
+      role: "USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB";
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -878,16 +805,7 @@ export interface components {
       /** @example $2b$10$hfRNI.V7ewuN/K.5eSt6oelaQ.FDj6irfUNR9wkKnL/qsNT23aE4i */
       hash: string;
       /** @enum {string} */
-      role:
-        | 'USER'
-        | 'QUANTIFIER'
-        | 'FORWARDER'
-        | 'ADMIN'
-        | 'ROOT'
-        | 'API_KEY_READWRITE'
-        | 'API_KEY_READ'
-        | 'API_KEY_DISCORD_BOT'
-        | 'API_KEY_SETUP_WEB';
+      role: "USER" | "QUANTIFIER" | "FORWARDER" | "ADMIN" | "ROOT" | "API_KEY_READWRITE" | "API_KEY_READ" | "API_KEY_DISCORD_BOT" | "API_KEY_SETUP_WEB";
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -935,7 +853,7 @@ export interface components {
        *   "0x345.."
        * ]
        */
-      owners: string[];
+      owners: (string)[];
       /** @example 0980987846534 */
       discordGuildId?: string;
     };
@@ -956,7 +874,7 @@ export interface components {
        *   "0x345.."
        * ]
        */
-      owners: string[];
+      owners: (string)[];
       /** @example 0980987846534 */
       discordGuildId?: string;
       /** @example oiujoiuoo8u */
@@ -964,7 +882,7 @@ export interface components {
       /** @example true */
       isPublic: boolean;
       /** @enum {string} */
-      discordLinkState: 'NOT_SET' | 'PENDING' | 'ACTIVE' | 'DEACTIVE';
+      discordLinkState: "NOT_SET" | "PENDING" | "ACTIVE" | "DEACTIVE";
     };
     UpdateCommunityInputDto: {
       /** @example banklessdao.givepraise.xyz */
@@ -979,7 +897,7 @@ export interface components {
        *   "0x345.."
        * ]
        */
-      owners?: string[];
+      owners?: (string)[];
     };
     CommunityPaginatedResponseDto: {
       /** @example 1200 */
@@ -1000,7 +918,7 @@ export interface components {
       prevPage?: Record<string, never>;
       /** @example 3 */
       nextPage?: Record<string, never>;
-      docs: readonly components['schemas']['Community'][];
+      docs: readonly (components["schemas"]["Community"])[];
       meta?: Record<string, never>;
     };
     IsNameAvailableResponseDto: {
@@ -1018,7 +936,7 @@ export interface components {
       duplicatePraise?: string;
     };
     QuantifyMultipleInputDto: {
-      params: components['schemas']['QuantifyInputDto'];
+      params: components["schemas"]["QuantifyInputDto"];
       /**
        * @example [
        *   "639b178f19296ee0f2d0585d",
@@ -1026,49 +944,49 @@ export interface components {
        *   "639b178f19296ee0f2d0585f"
        * ]
        */
-      praiseIds: string[];
+      praiseIds: (string)[];
     };
     SettingDto: {
       /**
-       * @description Type of the setting
-       * @example string
+       * @description Type of the setting 
+       * @example string 
        * @enum {string}
        */
-      type: 'string' | 'number' | 'boolean' | 'array';
+      type: "string" | "number" | "boolean" | "array";
       /**
-       * @description Default value for the setting
+       * @description Default value for the setting 
        * @example Some string
        */
       default: Record<string, never>;
       /**
-       * @description Description of the setting
+       * @description Description of the setting 
        * @example Description of the string setting
        */
       description: string;
       /**
-       * @description Markdown description of the setting
+       * @description Markdown description of the setting 
        * @example Description of the string setting
        */
       markdownDescription: string;
       /**
-       * @description Edit presentation style
-       * @example multiline
+       * @description Edit presentation style 
+       * @example multiline 
        * @enum {string}
        */
-      editPresentation?: 'multiline';
+      editPresentation?: "multiline";
       /**
-       * @description Order of the setting
+       * @description Order of the setting 
        * @example 1
        */
       order: number;
       /**
-       * @description Enum values for string type settings
+       * @description Enum values for string type settings 
        * @example [
        *   "left",
        *   "right"
        * ]
        */
-      enum?: string[];
+      enum?: (string)[];
       items: {
         type?: Record<string, never>;
       };
@@ -1098,16 +1016,16 @@ export interface components {
        *   "Praise receiver reports"
        * ]
        */
-      categories: string[];
+      categories: (string)[];
       /**
        * @example [
        *   "toplist"
        * ]
        */
-      keywords: string[];
+      keywords: (string)[];
       /** @description Configuration settings for the report */
       configuration: {
-        [key: string]: components['schemas']['SettingDto'] | undefined;
+        [key: string]: components["schemas"]["SettingDto"] | undefined;
       };
     };
   };
@@ -1121,23 +1039,24 @@ export interface components {
 export type external = Record<string, never>;
 
 export interface operations {
+
   /** Activate a user account in order to be able to give praise and receive rewards. Activation a user account creates a new User object or adds user account to User if it already exists. */
   ActivateController_activate: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['ActivateInputDto'];
+        "application/json": components["schemas"]["ActivateInputDto"];
       };
     };
     responses: {
       /** @description The created (or updated) user. */
       200: {
         content: {
-          'application/json': components['schemas']['User'];
+          "application/json": components["schemas"]["User"];
         };
       };
       201: {
         content: {
-          'application/json': components['schemas']['User'];
+          "application/json": components["schemas"]["User"];
         };
       };
     };
@@ -1147,7 +1066,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': string;
+          "application/json": string;
         };
       };
     };
@@ -1157,7 +1076,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'text/csv': string;
+          "text/csv": string;
         };
       };
     };
@@ -1167,7 +1086,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/octet-stream': string;
+          "application/octet-stream": string;
         };
       };
     };
@@ -1177,7 +1096,7 @@ export interface operations {
       /** @description All users */
       200: {
         content: {
-          'application/json': components['schemas']['User'][];
+          "application/json": (components["schemas"]["User"])[];
         };
       };
     };
@@ -1192,7 +1111,7 @@ export interface operations {
       /** @description A single user */
       200: {
         content: {
-          'application/json': components['schemas']['UserWithStatsDto'];
+          "application/json": components["schemas"]["UserWithStatsDto"];
         };
       };
     };
@@ -1206,14 +1125,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateUserRequestDto'];
+        "application/json": components["schemas"]["UpdateUserRequestDto"];
       };
     };
     responses: {
       /** @description Updated user */
       200: {
         content: {
-          'application/json': components['schemas']['UserWithStatsDto'];
+          "application/json": components["schemas"]["UserWithStatsDto"];
         };
       };
     };
@@ -1226,14 +1145,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateUserRoleInputDto'];
+        "application/json": components["schemas"]["UpdateUserRoleInputDto"];
       };
     };
     responses: {
       /** @description The updated user */
       200: {
         content: {
-          'application/json': components['schemas']['UserWithStatsDto'];
+          "application/json": components["schemas"]["UserWithStatsDto"];
         };
       };
     };
@@ -1246,14 +1165,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateUserRoleInputDto'];
+        "application/json": components["schemas"]["UpdateUserRoleInputDto"];
       };
     };
     responses: {
       /** @description The updated user */
       200: {
         content: {
-          'application/json': components['schemas']['UserWithStatsDto'];
+          "application/json": components["schemas"]["UserWithStatsDto"];
         };
       };
     };
@@ -1263,7 +1182,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': string;
+          "application/json": string;
         };
       };
     };
@@ -1273,7 +1192,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'text/csv': string;
+          "text/csv": string;
         };
       };
     };
@@ -1283,7 +1202,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/octet-stream': string;
+          "application/octet-stream": string;
         };
       };
     };
@@ -1297,14 +1216,14 @@ export interface operations {
         /** @example 1 */
         page: number;
         sortColumn?: string;
-        sortType?: 'asc' | 'desc';
+        sortType?: "asc" | "desc";
       };
     };
     responses: {
       /** @description Periods */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodPaginatedResponseDto'];
+          "application/json": components["schemas"]["PeriodPaginatedResponseDto"];
         };
       };
     };
@@ -1313,19 +1232,19 @@ export interface operations {
   PeriodsController_create: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['CreatePeriodInputDto'];
+        "application/json": components["schemas"]["CreatePeriodInputDto"];
       };
     };
     responses: {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodDetailsDto'];
+          "application/json": components["schemas"]["PeriodDetailsDto"];
         };
       };
       201: {
         content: {
-          'application/json': components['schemas']['PeriodDetailsDto'];
+          "application/json": components["schemas"]["PeriodDetailsDto"];
         };
       };
     };
@@ -1341,7 +1260,7 @@ export interface operations {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodDetailsDto'];
+          "application/json": components["schemas"]["PeriodDetailsDto"];
         };
       };
     };
@@ -1355,14 +1274,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdatePeriodInputDto'];
+        "application/json": components["schemas"]["UpdatePeriodInputDto"];
       };
     };
     responses: {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodDetailsDto'];
+          "application/json": components["schemas"]["PeriodDetailsDto"];
         };
       };
     };
@@ -1378,7 +1297,7 @@ export interface operations {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodDetailsDto'];
+          "application/json": components["schemas"]["PeriodDetailsDto"];
         };
       };
     };
@@ -1394,7 +1313,7 @@ export interface operations {
       /** @description Period Praise items */
       200: {
         content: {
-          'application/json': components['schemas']['PraiseWithUserAccountsWithUserRefDto'][];
+          "application/json": (components["schemas"]["PraiseWithUserAccountsWithUserRefDto"])[];
         };
       };
     };
@@ -1411,7 +1330,7 @@ export interface operations {
       /** @description Period Praise items */
       200: {
         content: {
-          'application/json': components['schemas']['PraiseWithUserAccountsWithUserRefDto'][];
+          "application/json": (components["schemas"]["PraiseWithUserAccountsWithUserRefDto"])[];
         };
       };
     };
@@ -1428,7 +1347,7 @@ export interface operations {
       /** @description Period Praise items */
       200: {
         content: {
-          'application/json': components['schemas']['PraiseWithUserAccountsWithUserRefDto'][];
+          "application/json": (components["schemas"]["PraiseWithUserAccountsWithUserRefDto"])[];
         };
       };
     };
@@ -1445,7 +1364,7 @@ export interface operations {
       /** @description Period Praise items */
       200: {
         content: {
-          'application/json': components['schemas']['PraiseWithUserAccountsWithUserRefDto'][];
+          "application/json": (components["schemas"]["PraiseWithUserAccountsWithUserRefDto"])[];
         };
       };
     };
@@ -1461,7 +1380,7 @@ export interface operations {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['VerifyQuantifierPoolSizeDto'];
+          "application/json": components["schemas"]["VerifyQuantifierPoolSizeDto"];
         };
       };
     };
@@ -1477,7 +1396,7 @@ export interface operations {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodDetailsDto'];
+          "application/json": components["schemas"]["PeriodDetailsDto"];
         };
       };
     };
@@ -1491,14 +1410,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['ReplaceQuantifierInputDto'];
+        "application/json": components["schemas"]["ReplaceQuantifierInputDto"];
       };
     };
     responses: {
       /** @description Period */
       200: {
         content: {
-          'application/json': components['schemas']['ReplaceQuantifierResponseDto'];
+          "application/json": components["schemas"]["ReplaceQuantifierResponseDto"];
         };
       };
     };
@@ -1512,16 +1431,16 @@ export interface operations {
         /** @example 1 */
         page: number;
         sortColumn?: string;
-        sortType?: 'asc' | 'desc';
+        sortType?: "asc" | "desc";
         search?: string;
-        types?: string[];
+        types?: (string)[];
       };
     };
     responses: {
       /** @description Paginated event logs */
       200: {
         content: {
-          'application/json': components['schemas']['EventLogPaginatedResponseDto'];
+          "application/json": components["schemas"]["EventLogPaginatedResponseDto"];
         };
       };
     };
@@ -1532,7 +1451,7 @@ export interface operations {
       /** @description Event log types */
       200: {
         content: {
-          'application/json': components['schemas']['EventLogType'][];
+          "application/json": (components["schemas"]["EventLogType"])[];
         };
       };
     };
@@ -1543,17 +1462,7 @@ export interface operations {
       query: {
         /** @example SETTING_KEY */
         key?: string;
-        type?:
-          | 'Integer'
-          | 'Float'
-          | 'String'
-          | 'Textarea'
-          | 'Boolean'
-          | 'IntegerList'
-          | 'StringList'
-          | 'Image'
-          | 'Radio'
-          | 'JSON';
+        type?: "Integer" | "Float" | "String" | "Textarea" | "Boolean" | "IntegerList" | "StringList" | "Image" | "Radio" | "JSON";
         /** @example 0 */
         group?: number;
         /** @example 0 */
@@ -1564,7 +1473,7 @@ export interface operations {
       /** @description All settings. */
       200: {
         content: {
-          'application/json': components['schemas']['Setting'][];
+          "application/json": (components["schemas"]["Setting"])[];
         };
       };
     };
@@ -1580,7 +1489,7 @@ export interface operations {
       /** @description Setting. */
       200: {
         content: {
-          'application/json': components['schemas']['Setting'];
+          "application/json": components["schemas"]["Setting"];
         };
       };
     };
@@ -1594,14 +1503,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['SetSettingDto'];
+        "application/json": components["schemas"]["SetSettingDto"];
       };
     };
     responses: {
       /** @description Updated setting. */
       200: {
         content: {
-          'application/json': components['schemas']['Setting'];
+          "application/json": components["schemas"]["Setting"];
         };
       };
     };
@@ -1617,7 +1526,7 @@ export interface operations {
       /** @description Updated setting. */
       200: {
         content: {
-          'application/json': components['schemas']['Setting'];
+          "application/json": components["schemas"]["Setting"];
         };
       };
     };
@@ -1632,7 +1541,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': Record<string, never>;
+          "application/json": Record<string, never>;
         };
       };
     };
@@ -1648,7 +1557,7 @@ export interface operations {
       /** @description All period settings */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodSetting'][];
+          "application/json": (components["schemas"]["PeriodSetting"])[];
         };
       };
     };
@@ -1665,7 +1574,7 @@ export interface operations {
       /** @description Period setting */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodSetting'];
+          "application/json": components["schemas"]["PeriodSetting"];
         };
       };
     };
@@ -1680,14 +1589,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['SetPeriodSettingDto'];
+        "application/json": components["schemas"]["SetPeriodSettingDto"];
       };
     };
     responses: {
       /** @description Updated period setting */
       200: {
         content: {
-          'application/json': components['schemas']['PeriodSetting'];
+          "application/json": components["schemas"]["PeriodSetting"];
         };
       };
     };
@@ -1701,7 +1610,7 @@ export interface operations {
         /** @example 1 */
         page: number;
         sortColumn?: string;
-        sortType?: 'asc' | 'desc';
+        sortType?: "asc" | "desc";
         giver?: string;
         receiver?: string;
       };
@@ -1710,7 +1619,7 @@ export interface operations {
       /** @description Paginated praise items */
       200: {
         content: {
-          'application/json': components['schemas']['PraisePaginatedResponseDto'];
+          "application/json": components["schemas"]["PraisePaginatedResponseDto"];
         };
       };
     };
@@ -1719,19 +1628,19 @@ export interface operations {
   PraiseController_praise: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['PraiseCreateInputDto'];
+        "application/json": components["schemas"]["PraiseCreateInputDto"];
       };
     };
     responses: {
       /** @description Praise item */
       200: {
         content: {
-          'application/json': components['schemas']['Praise'];
+          "application/json": components["schemas"]["Praise"];
         };
       };
       201: {
         content: {
-          'application/json': components['schemas']['Praise'][];
+          "application/json": (components["schemas"]["Praise"])[];
         };
       };
     };
@@ -1747,7 +1656,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': string;
+          "application/json": string;
         };
       };
     };
@@ -1763,7 +1672,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'text/csv': string;
+          "text/csv": string;
         };
       };
     };
@@ -1779,7 +1688,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/octet-stream': string;
+          "application/octet-stream": string;
         };
       };
     };
@@ -1795,7 +1704,7 @@ export interface operations {
       /** @description Praise item */
       200: {
         content: {
-          'application/json': components['schemas']['Praise'];
+          "application/json": components["schemas"]["Praise"];
         };
       };
     };
@@ -1804,19 +1713,19 @@ export interface operations {
   PraiseController_forward: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['PraiseForwardInputDto'];
+        "application/json": components["schemas"]["PraiseForwardInputDto"];
       };
     };
     responses: {
       /** @description Praise item */
       200: {
         content: {
-          'application/json': components['schemas']['Praise'];
+          "application/json": components["schemas"]["Praise"];
         };
       };
       201: {
         content: {
-          'application/json': components['schemas']['Praise'][];
+          "application/json": (components["schemas"]["Praise"])[];
         };
       };
     };
@@ -1836,7 +1745,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': components['schemas']['UserAccount'];
+          "application/json": components["schemas"]["UserAccount"];
         };
       };
     };
@@ -1845,13 +1754,13 @@ export interface operations {
   UserAccountsController_create: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['CreateUserAccountInputDto'];
+        "application/json": components["schemas"]["CreateUserAccountInputDto"];
       };
     };
     responses: {
       201: {
         content: {
-          'application/json': components['schemas']['CreateUserAccountResponseDto'];
+          "application/json": components["schemas"]["CreateUserAccountResponseDto"];
         };
       };
     };
@@ -1861,7 +1770,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': string;
+          "application/json": string;
         };
       };
     };
@@ -1871,7 +1780,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'text/csv': string;
+          "text/csv": string;
         };
       };
     };
@@ -1881,7 +1790,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/octet-stream': string;
+          "application/octet-stream": string;
         };
       };
     };
@@ -1897,7 +1806,7 @@ export interface operations {
       /** @description UserAccount */
       200: {
         content: {
-          'application/json': components['schemas']['UserAccount'];
+          "application/json": components["schemas"]["UserAccount"];
         };
       };
     };
@@ -1906,13 +1815,13 @@ export interface operations {
   UserAccountsController_update: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateUserAccountInputDto'];
+        "application/json": components["schemas"]["UpdateUserAccountInputDto"];
       };
     };
     responses: {
       200: {
         content: {
-          'application/json': components['schemas']['UpdateUserAccountResponseDto'];
+          "application/json": components["schemas"]["UpdateUserAccountResponseDto"];
         };
       };
     };
@@ -1923,7 +1832,7 @@ export interface operations {
       /** @description Array of API keys */
       200: {
         content: {
-          'application/json': components['schemas']['ApiKey'][];
+          "application/json": (components["schemas"]["ApiKey"])[];
         };
       };
     };
@@ -1932,14 +1841,14 @@ export interface operations {
   ApiKeyController_createApiKey: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['CreateApiKeyInputDto'];
+        "application/json": components["schemas"]["CreateApiKeyInputDto"];
       };
     };
     responses: {
       /** @description API key created */
       201: {
         content: {
-          'application/json': components['schemas']['CreateApiKeyResponseDto'];
+          "application/json": components["schemas"]["CreateApiKeyResponseDto"];
         };
       };
     };
@@ -1955,7 +1864,7 @@ export interface operations {
       /** @description An API key */
       200: {
         content: {
-          'application/json': components['schemas']['ApiKey'];
+          "application/json": components["schemas"]["ApiKey"];
         };
       };
     };
@@ -1969,19 +1878,19 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateDescriptionInputDto'];
+        "application/json": components["schemas"]["UpdateDescriptionInputDto"];
       };
     };
     responses: {
       200: {
         content: {
-          'application/json': components['schemas']['ApiKey'];
+          "application/json": components["schemas"]["ApiKey"];
         };
       };
       /** @description API key with updated description */
       201: {
         content: {
-          'application/json': components['schemas']['ApiKey'];
+          "application/json": components["schemas"]["ApiKey"];
         };
       };
     };
@@ -1996,13 +1905,13 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': components['schemas']['ApiKey'];
+          "application/json": components["schemas"]["ApiKey"];
         };
       };
       /** @description Revoked API key */
       201: {
         content: {
-          'application/json': components['schemas']['ApiKey'];
+          "application/json": components["schemas"]["ApiKey"];
         };
       };
     };
@@ -2012,14 +1921,14 @@ export interface operations {
     /** @description A request containing the user identityEthAddress */
     requestBody: {
       content: {
-        'application/json': components['schemas']['NonceInputDto'];
+        "application/json": components["schemas"]["NonceInputDto"];
       };
     };
     responses: {
       /** @description Nonce generated successfully */
       201: {
         content: {
-          'application/json': components['schemas']['NonceResponseDto'];
+          "application/json": components["schemas"]["NonceResponseDto"];
         };
       };
     };
@@ -2032,20 +1941,20 @@ export interface operations {
       };
     };
     /**
-     * @description A request containing the user identityEthAddress and signedlogin message. The signed message should be structured as follows:
-     *
+     * @description A request containing the user identityEthAddress and signedlogin message. The signed message should be structured as follows: 
+     * 
      * ```SIGN THIS MESSAGE TO LOGIN TO PRAISE.\n\nADDRESS:\n[identityEthAddress]\n\nNONCE:\n[nonce]```
      */
     requestBody: {
       content: {
-        'application/json': components['schemas']['LoginInputDto'];
+        "application/json": components["schemas"]["LoginInputDto"];
       };
     };
     responses: {
       /** @description User authenticated successfully */
       201: {
         content: {
-          'application/json': components['schemas']['LoginResponseDto'];
+          "application/json": components["schemas"]["LoginResponseDto"];
         };
       };
     };
@@ -2058,14 +1967,14 @@ export interface operations {
         /** @example 1 */
         page: number;
         sortColumn?: string;
-        sortType?: 'asc' | 'desc';
+        sortType?: "asc" | "desc";
       };
     };
     responses: {
       /** @description All communities */
       200: {
         content: {
-          'application/json': components['schemas']['CommunityPaginatedResponseDto'];
+          "application/json": components["schemas"]["CommunityPaginatedResponseDto"];
         };
       };
     };
@@ -2074,19 +1983,19 @@ export interface operations {
   CommunityController_create: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['CreateCommunityInputDto'];
+        "application/json": components["schemas"]["CreateCommunityInputDto"];
       };
     };
     responses: {
       /** @description Community */
       200: {
         content: {
-          'application/json': components['schemas']['Community'];
+          "application/json": components["schemas"]["Community"];
         };
       };
       201: {
         content: {
-          'application/json': components['schemas']['Community'];
+          "application/json": components["schemas"]["Community"];
         };
       };
     };
@@ -2101,7 +2010,7 @@ export interface operations {
       /** @description A single Community */
       200: {
         content: {
-          'application/json': components['schemas']['Community'];
+          "application/json": components["schemas"]["Community"];
         };
       };
     };
@@ -2110,14 +2019,14 @@ export interface operations {
   CommunityController_update: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['UpdateCommunityInputDto'];
+        "application/json": components["schemas"]["UpdateCommunityInputDto"];
       };
     };
     responses: {
       /** @description Community */
       200: {
         content: {
-          'application/json': components['schemas']['Community'];
+          "application/json": components["schemas"]["Community"];
         };
       };
     };
@@ -2133,7 +2042,7 @@ export interface operations {
       /** @description Checking whether the community name is available */
       200: {
         content: {
-          'application/json': components['schemas']['IsNameAvailableResponseDto'];
+          "application/json": components["schemas"]["IsNameAvailableResponseDto"];
         };
       };
     };
@@ -2142,14 +2051,14 @@ export interface operations {
   CommunityController_linkDiscord: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['LinkDiscordBotDto'];
+        "application/json": components["schemas"]["LinkDiscordBotDto"];
       };
     };
     responses: {
       /** @description Community */
       200: {
         content: {
-          'application/json': components['schemas']['Community'];
+          "application/json": components["schemas"]["Community"];
         };
       };
     };
@@ -2165,7 +2074,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/json': string;
+          "application/json": string;
         };
       };
     };
@@ -2181,7 +2090,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'text/csv': string;
+          "text/csv": string;
         };
       };
     };
@@ -2197,7 +2106,7 @@ export interface operations {
     responses: {
       200: {
         content: {
-          'application/octet-stream': string;
+          "application/octet-stream": string;
         };
       };
     };
@@ -2206,14 +2115,14 @@ export interface operations {
   QuantificationsController_quantifyMultiple: {
     requestBody: {
       content: {
-        'application/json': components['schemas']['QuantifyMultipleInputDto'];
+        "application/json": components["schemas"]["QuantifyMultipleInputDto"];
       };
     };
     responses: {
       /** @description Praise items */
       200: {
         content: {
-          'application/json': components['schemas']['Praise'][];
+          "application/json": (components["schemas"]["Praise"])[];
         };
       };
     };
@@ -2227,14 +2136,14 @@ export interface operations {
     };
     requestBody: {
       content: {
-        'application/json': components['schemas']['QuantifyInputDto'];
+        "application/json": components["schemas"]["QuantifyInputDto"];
       };
     };
     responses: {
       /** @description Praise /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.htmlitems */
       200: {
         content: {
-          'application/json': components['schemas']['Praise'][];
+          "application/json": (components["schemas"]["Praise"])[];
         };
       };
     };
@@ -2245,7 +2154,7 @@ export interface operations {
       /** @description A list of report manifests */
       200: {
         content: {
-          'application/json': components['schemas']['ReportManifestDto'][];
+          "application/json": (components["schemas"]["ReportManifestDto"])[];
         };
       };
       /** @description An error occurred while fetching report manifests */

--- a/packages/api/src/database/migrations/38_remove_uneeded_bot_settings.ts
+++ b/packages/api/src/database/migrations/38_remove_uneeded_bot_settings.ts
@@ -1,0 +1,26 @@
+import { SettingModel } from '../schemas/settings/23_settings.schema';
+
+const deleteSettings = [
+  {
+    key: 'DM_ERROR',
+  },
+  {
+    key: 'PRAISE_REASON_MISSING_ERROR',
+  },
+  {
+    key: 'PRAISE_SUCCESS_DM',
+  },
+];
+
+const up = async (): Promise<void> => {
+  // Remove redundant Discord Bot settings
+  const deleteSettingKeys = deleteSettings.map((s) => s.key);
+  await SettingModel.deleteMany({ key: { $in: deleteSettingKeys } });
+
+  await SettingModel.updateOne(
+    { key: 'PRAISE_GIVER_ROLE_ID' },
+    { $set: { defaultValue: null } },
+  );
+};
+
+export { up };

--- a/packages/discord-bot/src/handlers/forward.ts
+++ b/packages/discord-bot/src/handlers/forward.ts
@@ -64,11 +64,7 @@ export const forwardHandler: CommandHandler = async (
     if (!(await assertPraiseGiver(praiseGiver, interaction, true, host)))
       return;
 
-    const reason = interaction.options.getString('reason');
-    if (!reason || reason.length === 0) {
-      await ephemeralWarning(interaction, 'PRAISE_REASON_MISSING_ERROR', host);
-      return;
-    }
+    const reason = interaction.options.getString('reason', true);
 
     if (reason.length < 5 || reason.length > 280) {
       await ephemeralWarning(interaction, 'INVALID_REASON_LENGTH', host);

--- a/packages/discord-bot/src/handlers/praise.ts
+++ b/packages/discord-bot/src/handlers/praise.ts
@@ -54,10 +54,6 @@ export const praiseHandler: CommandHandler = async (
     }
 
     const reason = interaction.options.getString('reason', true);
-    if (!reason || reason.length === 0) {
-      await ephemeralWarning(interaction, 'PRAISE_REASON_MISSING_ERROR', host);
-      return;
-    }
 
     if (reason.length < 5 || reason.length > 280) {
       await ephemeralWarning(interaction, 'INVALID_REASON_LENGTH', host);

--- a/packages/discord-bot/src/utils/settingsUtil.ts
+++ b/packages/discord-bot/src/utils/settingsUtil.ts
@@ -21,14 +21,10 @@ export const getDefaultSetting = (
       return 'USER DOES NOT HAVE {@role} role (message not set)';
     case 'PRAISE_INVALID_RECEIVERS_ERROR':
       return 'VALID RECEIVERS NOT MENTIONED (message not set)';
-    case 'PRAISE_REASON_MISSING_ERROR':
-      return 'REASON NOT MENTIONED (message not set)';
     case 'PRAISE_UNDEFINED_RECEIVERS_WARNING':
       return 'UNDEFINED RECEIVERS MENTIONED, UNABLE TO PRAISE THEM (message not set)';
     case 'PRAISE_TO_ROLE_WARNING':
       return "ROLES MENTIONED AS PRAISE RECEIVERS, PRAISE CAN'T BE DISHED TO ROLES (message not set)";
-    case 'PRAISE_SUCCESS_DM':
-      return '[YOU HAVE BEEN PRAISED!!!]({praiseURL) (message not set)';
     case 'SELF_PRAISE_WARNING':
       return 'SELF-PRAISE NOT ALLOWED, PRAISE GIVERS UNABLE TO PRAISE THEMSELVES (message not set)';
     case 'FIRST_TIME_PRAISER':


### PR DESCRIPTION
This PR drops some redundant Discord Bot settings and sets the default value of `PRAISE_GIVER_ROLE_ID` to null.

fixes #1026 

* dependent on #1032