### PR TITLE
fix: hide activation link

### DIFF
--- a/packages/discord-bot/src/handlers/praise.ts
+++ b/packages/discord-bot/src/handlers/praise.ts
@@ -106,7 +106,7 @@ export const praiseHandler: CommandHandler = async (
         collector.on('collect', async (i) => {
           if (i.customId === `activate-${member.user.id}`) {
             const buttonIndex = i.message.components[0].components.findIndex(
-              (c) => c.customId == `activate-${member.user.id}`
+              (c) => c.customId === `activate-${member.user.id}`
             );
             const builder = new ActionRowBuilder<ButtonBuilder>();
             ActionRowBuilder.from(i.message.components[0]).components.forEach(

--- a/packages/discord-bot/src/handlers/praise.ts
+++ b/packages/discord-bot/src/handlers/praise.ts
@@ -1,4 +1,9 @@
-import { ComponentType, GuildMember } from 'discord.js';
+import {
+  ComponentType,
+  GuildMember,
+  ActionRowBuilder,
+  ButtonBuilder,
+} from 'discord.js';
 import { parseReceivers } from '../utils/parseReceivers';
 
 import { ephemeralWarning } from '../utils/renderMessage';
@@ -80,17 +85,48 @@ export const praiseHandler: CommandHandler = async (
         member,
         true
       );
-      if (!response) return;
+      if (!response) {
+        await interaction.editReply("Error: Can't run activation flow");
+        return;
+      }
+
+      const [message, activationUrl] = response;
 
       try {
-        const collector = response.createMessageComponentCollector({
+        const collector = message.createMessageComponentCollector({
           filter: (i) =>
-            i.user.id === interaction.user.id && i.customId === 'retry',
+            i.user.id === interaction.user.id &&
+            (i.customId === 'retry' ||
+              i.customId === `activate-${member.user.id}`) &&
+            i.isButton(),
           componentType: ComponentType.Button,
           time: 600000,
         });
 
         collector.on('collect', async (i) => {
+          if (i.customId === `activate-${member.user.id}`) {
+            const buttonIndex = i.message.components[0].components.findIndex(
+              (c) => c.customId == `activate-${member.user.id}`
+            );
+            const builder = new ActionRowBuilder<ButtonBuilder>();
+            ActionRowBuilder.from(i.message.components[0]).components.forEach(
+              (i, index) => {
+                if (i instanceof ButtonBuilder) {
+                  if (index === buttonIndex) i.setDisabled(true);
+                  builder.addComponents(i);
+                }
+              }
+            );
+            await i.update({
+              content: i.message.content,
+              components: [builder],
+            });
+            await i.followUp({
+              content: `Open this link and sign a message with your Ethereum wallet to activate: ${activationUrl}`,
+              ephemeral: true,
+            });
+            return;
+          }
           giverAccount = await getUserAccount(
             (member as GuildMember).user,
             host

--- a/packages/discord-bot/src/utils/sendActivationMessage.ts
+++ b/packages/discord-bot/src/utils/sendActivationMessage.ts
@@ -76,7 +76,8 @@ export const sendActivationMessage = async (
     }
 
     const response = await interaction.editReply({
-      content: `In order to dish praise, you need to activate your account by clicking the Activate button below, and signing a message with your Ethereum wallet: `,
+      content:
+        'In order to dish praise, you need to activate your account by clicking the Activate button below, and signing a message with your Ethereum wallet: ',
       components: [row],
     });
 

--- a/packages/discord-bot/src/utils/sendActivationMessage.ts
+++ b/packages/discord-bot/src/utils/sendActivationMessage.ts
@@ -6,17 +6,18 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   Message,
+  ButtonInteraction,
 } from 'discord.js';
 import { getUserAccount } from '../utils/getUserAccount';
 import { getActivateToken } from '../utils/getActivateToken';
 import { renderMessage } from '../utils/renderMessage';
 
 export const sendActivationMessage = async (
-  interaction: ChatInputCommandInteraction,
+  interaction: ChatInputCommandInteraction | ButtonInteraction,
   host: string,
   member: GuildMember | APIInteractionGuildMember,
   retry = false
-): Promise<Message | undefined> => {
+): Promise<[Message, string] | undefined> => {
   try {
     const userAccount = await getUserAccount(
       (member as GuildMember).user,
@@ -50,25 +51,36 @@ export const sendActivationMessage = async (
       member.user.id
     }&platform=DISCORD&token=${activateToken}`;
 
-    const activateButton = new ButtonBuilder()
-      .setLabel('Activate')
-      .setURL(activationURL)
-      .setStyle(ButtonStyle.Link);
-    const retryButton = new ButtonBuilder()
-      .setCustomId('retry')
-      .setLabel('Retry')
-      .setStyle(ButtonStyle.Success);
+    const row = new ActionRowBuilder<ButtonBuilder>();
 
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      activateButton
-    );
-    if (retry) row.addComponents(retryButton);
+    if (retry) {
+      row.addComponents(
+        new ButtonBuilder()
+          .setLabel('Activate')
+          .setCustomId(`activate-${member.user.id}`)
+          .setStyle(ButtonStyle.Primary)
+      );
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId('retry')
+          .setLabel('Retry')
+          .setStyle(ButtonStyle.Success)
+      );
+    } else {
+      row.addComponents(
+        new ButtonBuilder()
+          .setLabel('Activate')
+          .setURL(activationURL)
+          .setStyle(ButtonStyle.Link)
+      );
+    }
 
     const response = await interaction.editReply({
-      content: `In order to dish praise, you need to activate your account by following this link and signing a message using your Ethereum wallet. [Activate my account!](${activationURL})`,
+      content: `In order to dish praise, you need to activate your account by clicking the Activate button below, and signing a message with your Ethereum wallet: `,
       components: [row],
     });
-    return response;
+
+    return [response, activationURL];
   } catch (error) {
     await interaction.editReply({
       content: 'Unable to activate user account.',


### PR DESCRIPTION
This PR edits the activation flow the user is shown when praising for the first time. This makes the activation link ephemeral, so that others can't activate on that user's account.