### PR TITLE
Ensure needed db models are available för populate to work

### DIFF
--- a/packages/api/src/periods/services/periods.service.ts
+++ b/packages/api/src/periods/services/periods.service.ts
@@ -21,6 +21,12 @@ import { isQuantificationCompleted } from '../../quantifications/utils/is-quanti
 import { PaginateModel } from '../../shared/interfaces/paginate-model.interface';
 import { logger } from '../../shared/logger';
 import { DbService } from '../../database/services/db.service';
+import { Quantification } from '../../quantifications/schemas/quantifications.schema';
+import { QuantificationSchema } from '../../database/schemas/quantification/quantification.schema';
+import {
+  UserAccount,
+  UserAccountSchema,
+} from '../../useraccounts/schemas/useraccounts.schema';
 
 @Injectable({ scope: Scope.REQUEST })
 export class PeriodsService {
@@ -31,6 +37,11 @@ export class PeriodsService {
     private dbService: DbService,
     private settingsService: SettingsService,
   ) {
+    this.dbService.getModel<Quantification>(
+      Quantification.name,
+      QuantificationSchema,
+    ); // Ensure Quantification model is registered for population
+    this.dbService.getModel<UserAccount>(UserAccount.name, UserAccountSchema); // Ensure UserAccount model is registered for population
     this.periodModel = this.dbService.getPaginateModel<Period>(
       Period.name,
       PeriodSchema,

--- a/packages/api/src/quantifications/services/quantifications.service.ts
+++ b/packages/api/src/quantifications/services/quantifications.service.ts
@@ -15,6 +15,10 @@ import { logger } from '../../shared/logger';
 import { QuantificationSchema } from '../../database/schemas/quantification/quantification.schema';
 import { DbService } from '../../database/services/db.service';
 import { Injectable, Scope } from '@nestjs/common';
+import {
+  UserAccount,
+  UserAccountSchema,
+} from '../../useraccounts/schemas/useraccounts.schema';
 
 @Injectable({ scope: Scope.REQUEST })
 export class QuantificationsService {
@@ -27,6 +31,7 @@ export class QuantificationsService {
     private praiseService: PraiseService,
     private periodService: PeriodsService,
   ) {
+    this.dbService.getModel<UserAccount>(UserAccount.name, UserAccountSchema); // Ensure UserAccount model is registered for population
     this.quantificationModel = this.dbService.getModel<Quantification>(
       Quantification.name,
       QuantificationSchema,

--- a/packages/api/src/reports/reports.service.ts
+++ b/packages/api/src/reports/reports.service.ts
@@ -10,7 +10,7 @@ import {
   UserAccount,
   UserAccountSchema,
 } from '../useraccounts/schemas/useraccounts.schema';
-import { User } from '../users/schemas/users.schema';
+import { User, UserSchema } from '../users/schemas/users.schema';
 import { DbService } from '../database/services/db.service';
 
 const PROMPT_SUMMARY = `Below is a table of praise items describing contributions made by community member {user}. Summarize, what kind of work does {user} do for the community? The first column is a score representing the impact of the contribution, the second column describes the contribution. The higher impact score a contribution has the more it impacts your description of {user}. Also comment when in time contributions were made. The older the less impactful a contribution is. Max 400 characters. Paragraphs separated by "\n". Max 3 paragraphs.`;
@@ -31,6 +31,7 @@ export class ReportsService {
     this.octokit = new Octokit({
       userAgent: 'Praise API',
     });
+    this.dbService.getModel<User>(User.name, UserSchema); // Ensure User model is registered for population
     this.userAccountModel = this.dbService.getModel<UserAccount>(
       UserAccount.name,
       UserAccountSchema,

--- a/packages/api/src/useraccounts/useraccounts.service.ts
+++ b/packages/api/src/useraccounts/useraccounts.service.ts
@@ -8,12 +8,14 @@ import { CreateUserAccountResponseDto } from './dto/create-user-account-response
 import { FindUserAccountFilterDto } from './dto/find-user-account-filter.dto';
 import { errorMessages } from '../shared/exceptions/error-messages';
 import { DbService } from '../database/services/db.service';
+import { User, UserSchema } from '../users/schemas/users.schema';
 
 @Injectable()
 export class UserAccountsService {
   private userAccountModel: Model<UserAccount>;
 
   constructor(private dbService: DbService) {
+    this.dbService.getModel<User>(User.name, UserSchema); // Ensure User model is registered for population
     this.userAccountModel = this.dbService.getModel<UserAccount>(
       UserAccount.name,
       UserAccountSchema,

--- a/packages/api/src/users/users.service.ts
+++ b/packages/api/src/users/users.service.ts
@@ -5,7 +5,10 @@ import { Injectable, Scope } from '@nestjs/common';
 import { UpdateUserInputDto } from './dto/update-user-input.dto';
 import { CreateUserInputDto } from './dto/create-user-input.dto';
 import { ApiException } from '../shared/exceptions/api-exception';
-import { UserAccount } from '../useraccounts/schemas/useraccounts.schema';
+import {
+  UserAccount,
+  UserAccountSchema,
+} from '../useraccounts/schemas/useraccounts.schema';
 import { AuthRole } from '../auth/enums/auth-role.enum';
 import { UserWithStatsDto } from './dto/user-with-stats.dto';
 import { Praise, PraiseSchema } from '../praise/schemas/praise.schema';
@@ -26,6 +29,7 @@ export class UsersService {
     private periodService: PeriodsService,
     private dbService: DbService,
   ) {
+    this.dbService.getModel<UserAccount>(UserAccount.name, UserAccountSchema); // Ensure User model is registered for population
     this.userModel = this.dbService.getModel<User>(User.name, UserSchema);
     this.praiseModel = this.dbService.getModel<Praise>(
       Praise.name,


### PR DESCRIPTION
When using request scoped services not all db models are available at all times. We therefore need to ensure needed models are available to the services that need them. Specifically, for `populate` to work, the populated model needs to be available.